### PR TITLE
Remove `functions` from JSON configuration schema

### DIFF
--- a/envoy-test.conf
+++ b/envoy-test.conf
@@ -35,14 +35,7 @@
                 "name": "lambda",
                 "config": {
                   "access_key":"a",
-                  "secret_key":"b",
-                  "functions" : {
-                    "lambda-func1" : {
-                      "func_name" : "FunctionName",
-                      "hostname" : "lambda.us-east-1.amazonaws.com",
-                      "region" : "us-east-1"
-                    }
-                  }
+                  "secret_key":"b"
                 }
               },
               {

--- a/lambda_filter_config.cc
+++ b/lambda_filter_config.cc
@@ -8,7 +8,7 @@ namespace Envoy {
 namespace HTTP {
 namespace Configuration {
 
-const std::string lAMBDA_HTTP_FILTER_SCHEMA(R"EOF(
+const std::string LAMBDA_HTTP_FILTER_SCHEMA(R"EOF(
   {
     "$schema": "http://json-schema.org/schema#",
     "type" : "object",
@@ -18,20 +18,9 @@ const std::string lAMBDA_HTTP_FILTER_SCHEMA(R"EOF(
       },
       "secret_key": {
         "type" : "string"
-      },
-      "functions": {
-        "type" : "object",
-        "additionalProperties" : {
-          "type" : "object",
-          "properties": {
-            "func_name" : {"type":"string"},
-            "hostname" : {"type":"string"},
-            "region" : {"type":"string"}
-          }
-        }
       }
     },
-    "required": ["access_key", "secret_key", "functions"],
+    "required": ["access_key", "secret_key"],
     "additionalProperties" : false
   }
   )EOF");
@@ -43,28 +32,14 @@ public:
   createFilterFactory(const Envoy::Json::Object &json_config,
                       const std::string &,
                       Envoy::Server::Configuration::FactoryContext &) override {
-    json_config.validateSchema(lAMBDA_HTTP_FILTER_SCHEMA);
+    json_config.validateSchema(LAMBDA_HTTP_FILTER_SCHEMA);
 
     std::string access_key = json_config.getString("access_key", "");
     std::string secret_key = json_config.getString("secret_key", "");
-    const Envoy::Json::ObjectSharedPtr functions_obj =
-        json_config.getObject("functions", false);
 
-    ClusterFunctionMap functions;
-
-    functions_obj->iterate(
-        [&functions](const std::string &key, const Envoy::Json::Object &value) {
-          const std::string cluster_name = key;
-          const std::string func_name = value.getString("func_name", "");
-          const std::string hostname = value.getString("hostname", "");
-          const std::string region = value.getString("region", "");
-          functions[cluster_name] = Function{
-            func_name_ : func_name,
-            hostname_ : hostname,
-            region_ : region,
-          };
-          return true;
-        });
+    ClusterFunctionMap functions = {
+        {"lambda-func1",
+         {"FunctionName", "lambda.us-east-1.amazonaws.com", "us-east-1"}}};
 
     return [access_key, secret_key, functions](
                Envoy::Http::FilterChainFactoryCallbacks &callbacks) -> void {


### PR DESCRIPTION
1. Remove the `functions` map from the JSON configuration schema.
2. Make `ClusterFunctionMap functions` hard-coded for testing purposes.
   Eventually, function details should be retrieved from cluster metadata.
3. Fix a typo in `LAMBDA_HTTP_FILTER_SCHEMA`.