### PR TITLE
Move `LambdaFilterConfig::LambdaFilterConfig()` definition

### DIFF
--- a/lambda_filter.cc
+++ b/lambda_filter.cc
@@ -16,10 +16,6 @@
 namespace Envoy {
 namespace Http {
 
-LambdaFilterConfig::LambdaFilterConfig(const ProtoConfig &proto_config)
-    : aws_access_(proto_config.access_key()),
-      aws_secret_(proto_config.secret_key()) {}
-
 LambdaFilter::LambdaFilter(LambdaFilterConfigSharedPtr config,
                            ClusterFunctionMap functions)
     : config_(config), functions_(std::move(functions)), active_(false),

--- a/lambda_filter_config.h
+++ b/lambda_filter_config.h
@@ -12,7 +12,9 @@ class LambdaFilterConfig {
   using ProtoConfig = envoy::api::v2::filter::http::Lambda;
 
 public:
-  LambdaFilterConfig(const ProtoConfig &proto_config);
+  LambdaFilterConfig(const ProtoConfig &proto_config)
+      : aws_access_(proto_config.access_key()),
+        aws_secret_(proto_config.secret_key()) {}
 
   const std::string &aws_access() const { return aws_access_; }
   const std::string &aws_secret() const { return aws_secret_; }


### PR DESCRIPTION
Move the definition of `LambdaFilterConfig::LambdaFilterConfig()` from
`lambda_filter.cc` to `lambda_filter_config.h`.