### PR TITLE
Make member function names lowerCamelCase

### DIFF
--- a/aws_authenticator.cc
+++ b/aws_authenticator.cc
@@ -31,8 +31,7 @@ AwsAuthenticator::AwsAuthenticator(const std::string &access_key,
 
 AwsAuthenticator::~AwsAuthenticator() {}
 
-void AwsAuthenticator::update_payload_hash(
-    const Envoy::Buffer::Instance &data) {
+void AwsAuthenticator::updatePayloadHash(const Envoy::Buffer::Instance &data) {
 
   uint64_t num_slices = data.getRawSlices(nullptr, 0);
   Envoy::Buffer::RawSlice slices[num_slices];
@@ -42,9 +41,9 @@ void AwsAuthenticator::update_payload_hash(
   }
 }
 
-const Envoy::Http::HeaderEntry *AwsAuthenticator::get_maybe_inline_header(
-    Envoy::Http::HeaderMap *request_headers,
-    const Envoy::Http::LowerCaseString &im) {
+const Envoy::Http::HeaderEntry *
+AwsAuthenticator::getMaybeInlineHeader(Envoy::Http::HeaderMap *request_headers,
+                                       const Envoy::Http::LowerCaseString &im) {
 #define Q(x) #x
 #define QUOTE(x) Q(x)
 
@@ -88,7 +87,7 @@ void AwsAuthenticator::sign(Envoy::Http::HeaderMap *request_headers,
        header++) {
     const Envoy::Http::HeaderEntry *headerEntry = request_headers->get(*header);
     if (headerEntry == nullptr) {
-      headerEntry = get_maybe_inline_header(request_headers, *header);
+      headerEntry = getMaybeInlineHeader(request_headers, *header);
     }
 
     auto headerName = header->get();

--- a/aws_authenticator.h
+++ b/aws_authenticator.h
@@ -18,7 +18,7 @@ public:
 
   ~AwsAuthenticator();
 
-  void update_payload_hash(const Envoy::Buffer::Instance &data);
+  void updatePayloadHash(const Envoy::Buffer::Instance &data);
 
   void sign(Envoy::Http::HeaderMap *request_headers,
             std::list<Envoy::Http::LowerCaseString> &&headers_to_sign,
@@ -27,8 +27,8 @@ public:
 private:
   //  void lambdafy();
   const Envoy::Http::HeaderEntry *
-  get_maybe_inline_header(Envoy::Http::HeaderMap *request_headers,
-                          const Envoy::Http::LowerCaseString &im);
+  getMaybeInlineHeader(Envoy::Http::HeaderMap *request_headers,
+                       const Envoy::Http::LowerCaseString &im);
 
   static bool lowercasecompare(const Envoy::Http::LowerCaseString &i,
                                const Envoy::Http::LowerCaseString &j);

--- a/lambda_filter.cc
+++ b/lambda_filter.cc
@@ -19,7 +19,7 @@ namespace Http {
 LambdaFilter::LambdaFilter(LambdaFilterConfigSharedPtr config,
                            ClusterFunctionMap functions)
     : config_(config), functions_(std::move(functions)), active_(false),
-      awsAuthenticator_(aws_access(), aws_secret(),
+      awsAuthenticator_(awsAccess(), awsSecret(),
                         std::move(std::string("lambda"))) {}
 
 LambdaFilter::~LambdaFilter() {}
@@ -75,7 +75,7 @@ LambdaFilter::decodeData(Envoy::Buffer::Instance &data, bool end_stream) {
   ENVOY_LOG(debug, "decodeData called end = {} data = {}", end_stream,
             data.length());
 
-  awsAuthenticator_.update_payload_hash(data);
+  awsAuthenticator_.updatePayloadHash(data);
 
   if (end_stream) {
 

--- a/lambda_filter.h
+++ b/lambda_filter.h
@@ -36,8 +36,8 @@ private:
   const LambdaFilterConfigSharedPtr config_;
   StreamDecoderFilterCallbacks *decoder_callbacks_;
 
-  const std::string aws_access() const { return config_->aws_access(); }
-  const std::string aws_secret() const { return config_->aws_secret(); }
+  const std::string awsAccess() const { return config_->awsAccess(); }
+  const std::string awsSecret() const { return config_->awsSecret(); }
 
   ClusterFunctionMap functions_;
   Function currentFunction_;

--- a/lambda_filter_config.h
+++ b/lambda_filter_config.h
@@ -16,8 +16,8 @@ public:
       : aws_access_(proto_config.access_key()),
         aws_secret_(proto_config.secret_key()) {}
 
-  const std::string &aws_access() const { return aws_access_; }
-  const std::string &aws_secret() const { return aws_secret_; }
+  const std::string &awsAccess() const { return aws_access_; }
+  const std::string &awsSecret() const { return aws_secret_; }
 
 private:
   const std::string aws_access_;

--- a/test/lambda_filter_config_test.cc
+++ b/test/lambda_filter_config_test.cc
@@ -71,8 +71,8 @@ TEST(LambdaFilterConfigTest, AccessAndSecret) {
       Envoy::Json::Factory::loadFromString(json);
   auto config = constructLambdaFilterConfigFromJson(*json_config);
 
-  EXPECT_EQ(config.aws_access(), "a");
-  EXPECT_EQ(config.aws_secret(), "b");
+  EXPECT_EQ(config.awsAccess(), "a");
+  EXPECT_EQ(config.awsSecret(), "b");
 }
 
 } // namespace Envoy


### PR DESCRIPTION
Rename member function names with underscores to lowerCamelCase, for better
consistency with the Envoy project convention.