### PR TITLE
Introduce `MetadataFunctionRetriever::nonEmptyStringValue()`

### DIFF
--- a/function.h
+++ b/function.h
@@ -10,27 +10,6 @@ namespace Envoy {
 namespace Http {
 
 struct Function {
-  Function() : func_name_(""), hostname_(""), region_("") {}
-
-  Function(const std::string &func_name, const std::string &hostname,
-           const std::string &region)
-      : func_name_(func_name), hostname_(hostname), region_(region) {}
-
-  static Optional<Function> create(const std::string &func_name,
-                                   const std::string &hostname,
-                                   const std::string &region) {
-    auto function = Function(func_name, hostname, region);
-    if (function.valid()) {
-      return Optional<Function>(function);
-    }
-
-    return {};
-  }
-
-  bool valid() const {
-    return !(func_name_.empty() || hostname_.empty() || region_.empty());
-  }
-
   std::string func_name_;
   std::string hostname_;
   std::string region_;

--- a/metadata_function_retriever.h
+++ b/metadata_function_retriever.h
@@ -37,7 +37,7 @@ private:
                        const std::string &filter);
 
   static inline Optional<const std::string *>
-  stringValue(const FieldMap &fields, const std::string &key);
+  nonEmptyStringValue(const FieldMap &fields, const std::string &key);
 };
 
 } // namespace Http


### PR DESCRIPTION
1. Rename `MetadataFunctionRetriever::stringValue()` to
   `nonEmptyStringValue()`.
2. Make `nonEmptyStringValue()` return an invalid `Optional<>` unless the
   value is a non-empty string.
3. Make `struct Function` an aggregate type.
   Upon aggregate initialization, it is the caller's responsibility to
   validate the arguments.
4. Add relevant test cases to `MetadataFunctionRetrieverTest`.