### PR TITLE
Rename "envoy.lambda" to "io.solo.lambda"

### DIFF
--- a/lambda_filter_config_factory.cc
+++ b/lambda_filter_config_factory.cc
@@ -54,7 +54,7 @@ ProtobufTypes::MessagePtr LambdaFilterConfigFactory::createEmptyConfigProto() {
   return ProtobufTypes::MessagePtr{new envoy::api::v2::filter::http::Lambda()};
 }
 
-std::string LambdaFilterConfigFactory::name() { return "envoy.lambda"; }
+std::string LambdaFilterConfigFactory::name() { return "io.solo.lambda"; }
 
 const envoy::api::v2::filter::http::Lambda
 LambdaFilterConfigFactory::translateLambdaFilter(

--- a/test/lambda_filter_integration_test.cc
+++ b/test/lambda_filter_integration_test.cc
@@ -10,7 +10,7 @@ namespace Envoy {
 
 const std::string DEFAULT_LAMBDA_FILTER =
     R"EOF(
-name: envoy.lambda
+name: io.solo.lambda
 config:
     access_key: a
     secret_key: b


### PR DESCRIPTION
Use "io.solo.lambda" as the reverse DNS filter name.
The envoy.* namespace is reserved for Envoy's built-in filters.

See: [`message Metadata`](https://git.io/vNMkg).