### PR TITLE
keep bazel invoked by thetool happy

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,4 +1,4 @@
-workspace(name="aws_lambda_filter")
+workspace(name="aws_lambda")
 
 ENVOY_SHA = "f79a62b7cc9ca55d20104379ee0576617630cdaa"  # Feb 15, 2018 ( test: fix nit after #2591 (#2601) )
 


### PR DESCRIPTION
Keeping Bazel happy to avoid:

```WARNING: /root/.cache/bazel/_bazel_root/b570b5ccd0454dc9af9f65ab1833764d/external/lambda/WORKSPACE:1: 
Workspace name in /root/.cache/bazel/_bazel_root/b570b5ccd0454dc9af9f65ab1833764d/external/lambda/WORKSPACE 
(@aws_lambda_filter) does not match the name given in the repository's definition (@lambda); 
this will cause a build error in future versions```

Will change gloo-plugins so the feature is called `aws_lambda`